### PR TITLE
`attachment create`に`--mime_type`を追加

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,7 @@
 		"--init",
 		"--net=host",
 		"--env=CONFLUENCE_USER_NAME",
-		"--env=CONFLUENCE_PASSWORD"
+		"--env=CONFLUENCE_USER_PASSWORD"
 	],
 	"postStartCommand": "poetry install",
 	"customizations": {

--- a/confluence/attachment/create_attachment.py
+++ b/confluence/attachment/create_attachment.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 def create_attachments_from_file_list(
-    api: Api, content_id: str, query_params: dict[str, Any], files: list[Path], filename_pattern: None | str
+    api: Api, content_id: str, query_params: dict[str, Any], files: list[Path], filename_pattern: None | str, mime_type: None | str
 ) -> None:
     logger.info(f"{len(files)}件のファイルをアップロードします。")
     success_count = 0
@@ -26,7 +26,7 @@ def create_attachments_from_file_list(
 
         try:
             total_count += 1
-            api.create_attachment(content_id, file, query_params=query_params)
+            api.create_attachment(content_id, file, query_params=query_params, mime_type=mime_type)
             logger.debug(f"{total_count+1}件目: '{file}'をアップロードしました。")
         except Exception:
             logger.warning(f"'{file}'のアップロードに失敗しました。", exc_info=True)
@@ -38,7 +38,9 @@ def create_attachments_from_file_list(
     logger.info(f"{success_count}/{total_count} 件のファイルをアップロードしました。")
 
 
-def create_attachments_from_directory(api: Api, content_id: str, query_params: dict[str, Any], directory: Path, filename_pattern: None | str) -> None:
+def create_attachments_from_directory(
+    api: Api, content_id: str, query_params: dict[str, Any], directory: Path, filename_pattern: None | str, mime_type: None | str
+) -> None:
     success_count = 0
     total_count = 0
     if not directory.is_dir():
@@ -54,7 +56,7 @@ def create_attachments_from_directory(api: Api, content_id: str, query_params: d
             continue
         try:
             total_count += 1
-            api.create_attachment(content_id, file, query_params=query_params)
+            api.create_attachment(content_id, file, query_params=query_params, mime_type=mime_type)
             logger.debug(f"{total_count}件目: '{file}'をアップロードしました。")
         except Exception:
             logger.warning(f"'{file}'のアップロードに失敗しました。", exc_info=True)
@@ -69,9 +71,9 @@ def main(args: argparse.Namespace) -> None:
     content_id = args.content_id
     query_params = {"allowDuplicated": args.allow_duplicated}
     if args.file is not None:
-        create_attachments_from_file_list(api, content_id, query_params, args.file, filename_pattern=args.filename_pattern)
+        create_attachments_from_file_list(api, content_id, query_params, args.file, filename_pattern=args.filename_pattern, mime_type=args.mime_type)
     elif args.dir is not None:
-        create_attachments_from_directory(api, content_id, query_params, args.dir, filename_pattern=args.filename_pattern)
+        create_attachments_from_directory(api, content_id, query_params, args.dir, filename_pattern=args.filename_pattern, mime_type=args.mime_type)
 
 
 def add_arguments_to_parser(parser: argparse.ArgumentParser):
@@ -80,6 +82,8 @@ def add_arguments_to_parser(parser: argparse.ArgumentParser):
     file_group = parser.add_mutually_exclusive_group(required=True)
     file_group.add_argument("--file", type=Path, nargs="+", help="アップロードするファイル")
     file_group.add_argument("--dir", type=Path, help="アップロードするディレクトリ")
+
+    parser.add_argument("--mime_type", type=str, help="ファイル名からMIMEタイプが判別できないときに、この値を添付ファイルのMIMEタイプとします。")
 
     parser.add_argument("--allow_duplicated", action="store_true", help="指定した場合は、すでに同じファイルが存在しても上書きします。")
 

--- a/confluence/common/api.py
+++ b/confluence/common/api.py
@@ -63,12 +63,21 @@ class Api:
         url = f"content/{content_id}/child/attachment"
         return self._request("get", url, params=query_params).json()
 
-    def create_attachment(self, content_id: str, file: Path, *, query_params: Optional[QueryParams] = None) -> dict[str, Any]:
+    def create_attachment(
+        self, content_id: str, file: Path, *, query_params: Optional[QueryParams] = None, mime_type: Optional[str] = None
+    ) -> dict[str, Any]:
+        """
+        Args:
+            mime_type: mimetypes.guess_type()で自動判定でMIMEタイプを取得できないときに、この値をMIMEタイプにします。
+        """
         headers = {"X-Atlassian-Token": "nocheck"}
         url = f"content/{content_id}/child/attachment"
-        mime_type, _ = mimetypes.guess_type(file)
+        new_mime_type, _ = mimetypes.guess_type(file)
+        if new_mime_type is None:
+            new_mime_type = mime_type
+
         with file.open("rb") as f:
-            files = {"file": (file.name, f, mime_type)}
+            files = {"file": (file.name, f, new_mime_type)}
             return self._request("post", url, params=query_params, files=files, headers=headers).json()
 
     def get_content(self, *, query_params: Optional[QueryParams] = None) -> list[dict[str, Any]]:


### PR DESCRIPTION
# 対応前の状態
拡張子がない画像ファイルから添付ファイルを作成すると、Confluenceは画像ファイルと認識しない。
そのファイルを参照するXMLを、source editorに入力すると画像は表示されない。

https://qiita.com/yuji38kwmt/items/ea09b70a06ac99f9c865

# 対応後の状態
拡張子がないファイルに対して、MIMEタイプを指定できるようにした。
